### PR TITLE
RN 0.26 breaking change support - import react, comp and proptype fro…

### DIFF
--- a/Tab.js
+++ b/Tab.js
@@ -1,10 +1,13 @@
 import React, {
   Component,
+  PropTypes
+} from 'react';
+
+import {
   processColor,
-  PropTypes,
   requireNativeComponent,
   View,
-} from 'react-native';
+} from 'react-native'
 
 const AndroidTab = requireNativeComponent('Tab', Tab);
 

--- a/TabLayout.js
+++ b/TabLayout.js
@@ -1,10 +1,13 @@
 import React, {
   Component,
+  PropTypes
+} from 'react';
+
+import {
   processColor,
-  PropTypes,
   requireNativeComponent,
   View,
-} from 'react-native';
+} from 'react-native'
 
 const AndroidTabLayout = requireNativeComponent('TabLayout', TabLayout);
 


### PR DESCRIPTION
This change is to support the breaking changes on RN 0.26. 
React, Component and PropTypes should be imported from React package, not from React-native.
Otherwise we get a RED Screen, displaying bug #20 
