### PR TITLE
Update to fix the crash on RN 0.32

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -30,6 +30,6 @@ repositories {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:0.19.+'
+    compile 'com.facebook.react:react-native:0.32.+'
     compile 'com.android.support:design:23.0.1'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -30,6 +30,6 @@ repositories {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:0.32.+'
+    compile 'com.facebook.react:react-native:+'
     compile 'com.android.support:design:23.0.1'
 }

--- a/android/src/main/java/com/xebia/reactnative/ReactTabStub.java
+++ b/android/src/main/java/com/xebia/reactnative/ReactTabStub.java
@@ -12,7 +12,6 @@ import android.view.ViewGroup;
 import android.widget.FrameLayout;
 import android.widget.ImageView;
 import android.widget.TextView;
-import com.facebook.stetho.common.StringUtil;
 
 public class ReactTabStub extends ViewGroup {
   public static final String TAG = "ReactTabStub";

--- a/android/src/main/java/com/xebia/reactnative/TabSelectedEvent.java
+++ b/android/src/main/java/com/xebia/reactnative/TabSelectedEvent.java
@@ -11,7 +11,7 @@ public class TabSelectedEvent extends Event<TabSelectedEvent> {
   private final int position;
 
   public TabSelectedEvent(int viewTag, int position) {
-    super(viewTag, SystemClock.uptimeMillis());
+    super(viewTag);
     this.position = position;
   }
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
     "husky": "0.11.4"
   },
   "peerDependencies": {
-    "react-native": "0.32"
+    "react-native": "0.33"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
     "husky": "0.11.4"
   },
   "peerDependencies": {
-    "react-native": "0.28"
+    "react-native": "0.32"
   }
 }


### PR DESCRIPTION
This PR updates the component to support React Native 0.32.

The type signature of the constructor of `com.facebook.react.uimanager.events.Event` has been changed due to: https://github.com/facebook/react-native/commit/da063e3d55a4fcd617ac496d62aa051343f35b56#diff-83ea119f0177e3a5cdf1563ae82b471d
